### PR TITLE
Change port config

### DIFF
--- a/logindirector/Program.cs
+++ b/logindirector/Program.cs
@@ -18,7 +18,7 @@ namespace logindirector
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
-            .UseCloudHosting(5000, 2021)
+            .UseCloudHosting(2021)
             .AddCloudFoundryConfiguration()
 
                 .ConfigureAppConfiguration((hostingContext, config) =>

--- a/logindirector/Properties/launchSettings.json
+++ b/logindirector/Properties/launchSettings.json
@@ -11,7 +11,7 @@
     "logindirector": {
       "commandName": "Project",
       "launchBrowser": true,
-      "applicationUrl": "https://localhost:2021;http://localhost:5000",
+      "applicationUrl": "https://localhost:2021;http://localhost:2021",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }


### PR DESCRIPTION
This seems to have reverted - we need to always be running on port 2021 regardless of access protocol