### PR TITLE
Rework the central cache session management - sometimes we can end up…

### DIFF
--- a/logindirector/Controllers/SessionController.cs
+++ b/logindirector/Controllers/SessionController.cs
@@ -85,6 +85,11 @@ namespace logindirector.Controllers
 
             if (_memoryCache.TryGetValue(cacheKey, out sessionsList))
             {
+                if (sessionsList == null)
+                {
+                    sessionsList = new List<UserSessionModel>();
+                }
+
                 sessionsList = sessionsList.Where(p => p.sessionId != sessionId).ToList();
             }
 


### PR DESCRIPTION
… with a null list in memory, which causes exceptions.  Always check for this before using it