### PR TITLE
Use Alpine 3.19 ASP .NET image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 #See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0-alpine AS base
+FROM mcr.microsoft.com/dotnet/aspnet:6.0-alpine3.19 AS base
 WORKDIR /app
 EXPOSE 80
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM mcr.microsoft.com/dotnet/aspnet:6.0-alpine3.19 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.19 AS build
 WORKDIR /src
 COPY ["logindirector/logindirector.csproj", "."]
 RUN dotnet restore "./logindirector.csproj"
@@ -16,7 +16,7 @@ FROM build AS publish
 RUN dotnet publish "logindirector.csproj" -c Release -o /app/publish /p:UseAppHost=false
 
 FROM base AS final
-RUN apk upgrade && apk add curl && rm -rf /var/cache/apk
+RUN apk update && apk upgrade && apk add curl && rm -rf /var/cache/apk
 WORKDIR /app
 COPY --from=publish /app/publish .
 ENTRYPOINT ["dotnet", "logindirector.dll"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ FROM build AS publish
 RUN dotnet publish "logindirector.csproj" -c Release -o /app/publish /p:UseAppHost=false
 
 FROM base AS final
-RUN apk update && apk upgrade && apk add curl && rm -rf /var/cache/apk
+RUN apk upgrade && apk add curl && rm -rf /var/cache/apk
 WORKDIR /app
 COPY --from=publish /app/publish .
 ENTRYPOINT ["dotnet", "logindirector.dll"]


### PR DESCRIPTION
To ensure that outdated packages are eliminated. 